### PR TITLE
refatorando lógica do ataque do bot.

### DIFF
--- a/backend/controllers/board.js
+++ b/backend/controllers/board.js
@@ -108,25 +108,33 @@ const attack = (req, res) => {
         // Array para armazenar os ataques do bot
         let botAttacks = [];
         let botContinueAttacking = true;
-        
-        // Bot continua atacando enquanto acertar e não tiver destruído o navio
-        while (botContinueAttacking) {
+
+        const MAX_BOT_ATTACKS = 100; // Limite para evitar loop infinito
+        let botAttackCount = 0;
+
+        // Bot continua atacando enquanto acertar
+        while (botContinueAttacking && botAttackCount < MAX_BOT_ATTACKS) {
             const [botRow, botCol] = smartBotAttack(playerBoard);
             const botResult = playerBoard.placeBomb(botRow, botCol);
-            
+
             botAttacks.push({
                 row: botRow,
                 column: botCol,
                 ...botResult
             });
-            
-            // Verifica se o bot deve continuar atacando (acertou, mas não destruiu)
-            botContinueAttacking = botResult.hit && !botResult.destroyed;
-            
+
+            // Agora o bot continua atacando enquanto acertar, independente de destruir
+            botContinueAttacking = botResult.hit;
+            botAttackCount++;
+
             console.log(`Bot atacou (${botRow}, ${botCol}): ${botResult.hit ? 'ACERTOU' : 'ERROU'}`);
             if (botResult.destroyed) {
                 console.log(`Bot DESTRUIU um ${botResult.shipType}!`);
             }
+        }
+
+        if (botAttackCount >= MAX_BOT_ATTACKS) {
+            console.warn("⚠️ Limite máximo de ataques do bot atingido! Possível loop evitado.");
         }
 
         res.status(200).json({
@@ -134,7 +142,7 @@ const attack = (req, res) => {
                 row, column,
                 ...playerResult
             },
-            botAttacks: botAttacks
+            botAttacks
         });
 
     } catch (error) {
@@ -145,6 +153,7 @@ const attack = (req, res) => {
         });
     }
 };
+
 
 const startGame = (_, res) => {
     try {


### PR DESCRIPTION
1. Bot agora continua atacando enquanto acertar e mesmo que destrua o navio, mas passa a vez apenas ao errar o tiro.
2. Limitação de ataques do bot para evitar loop infinito (máximo de 100 ataques).
Já testada e funcionando.
![image](https://github.com/user-attachments/assets/60fd5331-94fa-4a95-a8cb-44f0c7d0e61f)
